### PR TITLE
Move converted files instead of renaming

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -1,6 +1,7 @@
 'use strict';
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
+var mv = require('mv');
 var S = require('string');
 var yaml = require('js-yaml');
 var colors = require('colors');
@@ -118,14 +119,14 @@ function convertFile(srcFile) {
       // do nothing, shit happens
     });
   } else {
-    fs.rename(config.srcDirectory + '/' + srcFile, config.dstDirectory + '/' + srcFile, function(err) {
+    mv(config.srcDirectory + '/' + srcFile, config.dstDirectory + '/' + srcFile, function(err) {
       if (err) {
         printErrorMsg(err.toString());
       }
     });
   }
 
-  fs.rename(config.srcDirectory + '/' + dstFile, config.dstDirectory + '/' + dstFile, function(err) {
+  mv(config.srcDirectory + '/' + dstFile, config.dstDirectory + '/' + dstFile, function(err) {
     if (err) {
       printErrorMsg(err.toString());
     }

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 'use strict';
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
+var mv = require('mv');
 var yaml = require('js-yaml');
 var moment = require('moment');
 var mkdirp = require('mkdirp');
@@ -310,7 +311,7 @@ function createCaptureProcess(model) {
               // do nothing, shit happens
             });
           } else {
-            fs.rename(config.captureDirectory + '/' + filename, config.completeDirectory + '/' + filename, function(err) {
+            mv(config.captureDirectory + '/' + filename, config.completeDirectory + '/' + filename, function(err) {
               if (err) {
                 printErrorMsg('[' + colors.green(model.nm) + '] ' + err.toString());
               }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"underscore": "^1.8.3",
 		"websocket": "^1.0.23",
 		"colors": "^1.1.2",
-		"httpdispatcher": "^2.0.0"
+		"httpdispatcher": "^2.0.0",
+		"mv": "^2.1.1",
 	}
 }


### PR DESCRIPTION
Added a dependency on `mv`, and changed all occurances of `fs.rename` with it.

`mv` will first try `fs.rename`, and if that fails it will copy the file and then remove the source. This allows mfc-node to support moving files to another (larger) disk.

Also see: https://github.com/andrewrk/node-mv .