### PR TITLE
Update main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -272,10 +272,16 @@ function createCaptureProcess(model) {
         '-v',
         'fatal',
         '-i',
-        'http://video' + (model.camserv - 500) + '.myfreecams.com:1935/NxServer/ngrp:mfc_' + (100000000 + model.uid) + '.f4v_mobile/playlist.m3u8?nc=1423603882490',
+        'http://video' + (model.camserv - 500) + '.myfreecams.com:1935/NxServer/ngrp:mfc_' + (100000000 + model.uid) + '.f4v_mobile/playlist.m3u8',
         // 'http://video' + (model.camserv - 500) + '.myfreecams.com:1935/NxServer/mfc_' + (100000000 + model.uid) + '.f4v_aac/playlist.m3u8?nc=1423603882490',
         '-c',
         'copy',
+        '-vsync',
+        '2',
+        '-r',
+        '60',
+        '-b:v',
+        '500k',
         config.captureDirectory + '/' + filename
       ];
 


### PR DESCRIPTION
By including a video bitrate, ffmpeg intelligently picks the HD streams whenever they are available. This is a *very* notable difference from  320x240 to 800x600. This also is something the user should be able to specify in configuration. 

Also on line 275, the '?nc=1423603882490' is not required by the site to offer the playlist to be recorded.